### PR TITLE
Harden self-hosted stack tooling and docs

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,0 +1,42 @@
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIPX_DEFAULT_PYTHON=/usr/bin/python3.11 \
+    PATH=/root/.local/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    git-lfs \
+    gnupg \
+    make \
+    build-essential \
+    software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 3.11 from deadsnakes
+RUN add-apt-repository ppa:deadsnakes/ppa -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
+       python3.11 \
+       python3.11-distutils \
+       python3.11-dev \
+       python3.11-venv \
+       pipx \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ensure python3 points to Python 3.11 and install pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && python3.11 -m ensurepip --upgrade
+
+# Node.js 20 (from NodeSource)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Developer tooling via pipx
+RUN pipx install poetry \
+    && pipx install uv \
+    && git lfs install --system
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "deflexnet-app",
+  "build": {
+    "dockerfile": "Dockerfile.dev",
+    "context": ".."
+  },
+  "runArgs": ["--gpus=all"],
+  "postCreateCommand": "git lfs install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-toolsai.jupyter",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,6 @@
 POSTGRES_USER=postgres
+# WARNING: The default password below is for local development only.
+# For any non-local or production deployment, CHANGE THIS TO A STRONG, UNIQUE PASSWORD.
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=app
 MINIO_ROOT_USER=minioadmin

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=app
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.env
+node_modules
+dist
+models/*
+!models/.gitkeep
+pgdata
+minio_data
+qdrant_data
+.ark/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,33 @@
+# Architecture
+
+```mermaid
+graph LR
+    subgraph CLI
+        ark[ark CLI]
+    end
+    ark --> compose[docker compose stack]
+    compose --> gateway[FastAPI Gateway]
+    compose --> vllm[vLLM OpenAI API]
+    compose --> builder[React Builder]
+    gateway -->|governance pack| pack[(constitutional_pack)]
+    gateway --> postgres[(Postgres)]
+    gateway --> minio[(MinIO)]
+    gateway --> qdrant[(Qdrant)]
+    builder -->|REST| gateway
+    gateway -->|OpenAI| vllm
+```
+
+* **Dev experience** – the `.devcontainer` image mirrors the runtime
+  requirements (CUDA 12.x, Python 3.11, Node.js 20) while bundling pipx, poetry,
+  uv, make, git, and git-lfs. VS Code (or any devcontainer-compatible editor)
+  attaches with GPU access enabled via the NVIDIA Container Toolkit.
+* **Runtime** – `docker-compose.yml` launches vLLM (serving
+  `Qwen/Qwen2.5-Coder-14B-Instruct` through an OpenAI-compatible API), the FastAPI
+  gateway, the React builder, and supporting datastores (Postgres, MinIO, Qdrant)
+  with health checks and startup ordering.
+* **Governance pack** – mounted read-only into the gateway, the constitutional
+  pack is surfaced through `/court/trifecta` and exposed in the builder UI.
+* **CLI tooling** – `scripts/ark` wraps environment checks, compose orchestration,
+  and helper workflows (logs streaming, court request helper, placeholder
+  codegen). `scripts/check_env.sh` validates GPU visibility and port availability
+  before the stack is started.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
 # deflexnet-app
+
+Self-hosted agent playground featuring a CUDA-enabled vLLM model server, a FastAPI
+agent gateway wired to a constitutional governance pack, and a React builder UI.
+
+## Prerequisites
+
+* Docker with the NVIDIA Container Toolkit (`nvidia-smi` should succeed)
+* CUDA-capable GPU with driver version compatible with CUDA 12.x
+* Optional developer tooling: Node.js 20, Python 3.11, pipx, poetry, uv (also
+  provided inside the devcontainer)
+
+Run the built-in environment validation before starting the stack:
+
+```bash
+./scripts/ark check
+```
+
+The command verifies Docker connectivity, GPU visibility, and that all runtime
+ports are free.
+
+## One-command bring-up
+
+```bash
+./scripts/ark up
+```
+
+`ark` ensures a `.env` file exists, builds the Docker images, and starts the
+compose stack in the background. Bring everything down with:
+
+```bash
+./scripts/ark down
+```
+
+Tail runtime logs with:
+
+```bash
+./scripts/ark logs
+```
+
+You can perform the same actions with vanilla Docker Compose:
+
+```bash
+docker compose --env-file .env up --build
+```
+
+## Services & health checks
+
+* Gateway (FastAPI) — <http://localhost:8000/healthz>
+* vLLM OpenAI-compatible API — <http://localhost:8001/v1/models>
+* Builder UI — <http://localhost:3000>
+* MinIO console — <http://localhost:9001>
+
+Once the stack is running, verify the key endpoints:
+
+```bash
+curl http://localhost:8000/healthz
+curl http://localhost:8001/v1/models
+```
+
+## Court trifecta demo
+
+The governance pack mounted into the gateway powers a stubbed `/court/trifecta`
+endpoint. Submit a plan using the helper CLI:
+
+```bash
+./scripts/ark court examples/trifecta_example.json
+```
+
+The command pretty-prints the verdict and returns a success exit code when the
+response is `PASS` or `PASS_WITH_CONDITIONS`.
+
+## Builder walkthrough
+
+Open the builder UI at [http://localhost:3000](http://localhost:3000). The demo
+screen loads the FastAPI health endpoint to confirm connectivity, exposes the
+constitutional pack sections, and lets you tweak the JSON plan before invoking
+the court trifecta endpoint. Verdict, summary, and pack contents render directly
+in the browser.
+
+## Devcontainer
+
+The `.devcontainer/` folder ships a CUDA-ready development environment powered by
+`nvidia/cuda:12.1.1-runtime-ubuntu22.04`. It includes Python 3.11, Node.js 20,
+pipx, poetry, uv, make, git, git-lfs, and build essentials. Open the repository
+in VS Code (or use `devcontainer open`) to get a fully provisioned workspace
+with GPU access via the NVIDIA Container Toolkit.
+
+## Governance pack
+
+`constitutional_pack/` is mounted read-only into the gateway container. Each
+section (`Scripture`, `Geometry`, `Law`) can be updated locally and the builder
+UI will surface the new contents on the next request.
+
+## CLI extras
+
+The `ark` CLI also includes a placeholder code generation helper:
+
+```bash
+./scripts/ark dev codegen "Refactor the gateway tools API"
+```
+
+The prompt is echoed into `.ark/changeset-<timestamp>.md`, simulating future
+automation workflows.

--- a/builder/.dockerignore
+++ b/builder/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+dist
+.vite

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS build
+ENV NODE_ENV=development
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/builder/index.html
+++ b/builder/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Builder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "builder",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview --port 3000"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.30",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/builder/postcss.config.js
+++ b/builder/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/builder/src/App.jsx
+++ b/builder/src/App.jsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react';
+import './index.css';
+
+const defaultPlan = JSON.stringify(
+  {
+    case: 'demo',
+    evidence: ['A', 'B', 'C'],
+    verdict: 'pending'
+  },
+  null,
+  2
+);
+
+export default function App() {
+  const [health, setHealth] = useState({ status: 'checking', pack_sections: [] });
+  const [plan, setPlan] = useState(defaultPlan);
+  const [verdict, setVerdict] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/healthz')
+      .then(r => r.json())
+      .then(d => setHealth(d))
+      .catch(() => setHealth({ status: 'error', pack_sections: [] }));
+  }, []);
+
+  const runTrifecta = async () => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const parsed = JSON.parse(plan);
+      const response = await fetch('http://localhost:8000/court/trifecta', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed)
+      });
+
+      if (!response.ok) {
+        throw new Error(`gateway returned HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      setVerdict(data);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        setError('Plan must be valid JSON.');
+      } else {
+        setError(err.message ?? 'Unknown error');
+      }
+      setVerdict(null);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-900/50 px-6 py-4">
+        <h1 className="text-2xl font-semibold">Deflex Builder</h1>
+       <p className="text-sm text-slate-400">
+         FastAPI gateway status: <span className="font-mono">{health.status}</span>
+       </p>
+        {health.vllm_api_base ? (
+          <p className="text-xs text-slate-500">
+            vLLM API base: <span className="font-mono">{health.vllm_api_base}</span>
+          </p>
+        ) : null}
+        {health.pack_sections?.length ? (
+          <p className="text-xs text-slate-500">
+            Constitutional pack mounted with sections: {health.pack_sections.join(', ')}
+          </p>
+        ) : null}
+      </header>
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-8 lg:flex-row">
+        <section className="w-full lg:w-1/2">
+          <h2 className="text-xl font-semibold">Trifecta Plan</h2>
+          <p className="mb-4 text-sm text-slate-400">
+            Edit the JSON plan and submit it to <code className="rounded bg-slate-800 px-1">/court/trifecta</code>.
+          </p>
+          <textarea
+            className="h-64 w-full rounded border border-slate-800 bg-slate-900 font-mono text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            value={plan}
+            onChange={event => setPlan(event.target.value)}
+          />
+          <button
+            className="mt-4 inline-flex items-center gap-2 rounded bg-indigo-500 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-700"
+            onClick={runTrifecta}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Submitting…' : 'Run court trifecta'}
+          </button>
+          {error ? <p className="mt-2 text-sm text-red-400">{error}</p> : null}
+        </section>
+
+        <section className="w-full lg:w-1/2">
+          <h2 className="text-xl font-semibold">Result</h2>
+          {!verdict ? (
+            <p className="mt-2 text-sm text-slate-400">
+              Submit a plan to view the verdict and the mounted governance pack contents.
+            </p>
+          ) : (
+            <div className="mt-3 space-y-4">
+              <div className="rounded border border-slate-800 bg-slate-900 p-4">
+                <h3 className="text-lg font-semibold">Verdict: {verdict.result}</h3>
+                {verdict.conditions?.length ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+                    {verdict.conditions.map((item, index) => (
+                      <li key={index}>{item}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+
+              <div className="rounded border border-slate-800 bg-slate-900 p-4">
+                <h3 className="text-lg font-semibold">Summary</h3>
+                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap text-sm text-slate-300">
+                  {JSON.stringify(verdict.summary, null, 2)}
+                </pre>
+              </div>
+
+              <div className="rounded border border-slate-800 bg-slate-900 p-4">
+                <h3 className="text-lg font-semibold">Constitutional Pack</h3>
+                {verdict.pack?.sections?.map(section => (
+                  <details key={section.name} className="group">
+                    <summary className="cursor-pointer text-sm font-semibold text-indigo-400">
+                      {section.name}
+                    </summary>
+                    <pre className="mt-2 overflow-x-auto whitespace-pre-wrap text-xs text-slate-300">
+                      {section.content || 'No content found.'}
+                    </pre>
+                  </details>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/builder/src/App.jsx
+++ b/builder/src/App.jsx
@@ -46,7 +46,7 @@ export default function App() {
       if (err instanceof SyntaxError) {
         setError('Plan must be valid JSON.');
       } else {
-        setError(err.message ?? 'Unknown error');
+        setError(err.message || 'Unknown error');
       }
       setVerdict(null);
     } finally {

--- a/builder/src/index.css
+++ b/builder/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/builder/src/main.jsx
+++ b/builder/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/builder/tailwind.config.js
+++ b/builder/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/builder/vite.config.js
+++ b/builder/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 3000
+  }
+});

--- a/constitutional_pack/Geometry/README.md
+++ b/constitutional_pack/Geometry/README.md
@@ -1,0 +1,6 @@
+# Geometry
+
+- Agents must describe the operational space (databases, tools, models) before
+  acting.
+- Interactions should be decomposed into auditable, ordered steps.
+- Feedback loops are encouraged when uncertainty is detected.

--- a/constitutional_pack/Law/README.md
+++ b/constitutional_pack/Law/README.md
@@ -1,0 +1,5 @@
+# Law
+
+* All actions must respect user consent and organizational policy.
+* Store sensitive artifacts in approved systems (Postgres, MinIO, Qdrant).
+* Escalate to human review when conflicts between scripture and geometry arise.

--- a/constitutional_pack/Scripture/README.md
+++ b/constitutional_pack/Scripture/README.md
@@ -1,0 +1,5 @@
+# Scripture
+
+1. Uphold clarity in every response.
+2. Prefer transparency over obfuscation.
+3. Align outcomes with constitutional guardrails supplied by the operator.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,129 @@
+version: '3.9'
+
+services:
+  vllm:
+    image: vllm/vllm-openai:0.5.1
+    command: >-
+      --model Qwen/Qwen2.5-Coder-14B-Instruct
+      --host 0.0.0.0
+      --port 8000
+    ports:
+      - "8001:8000"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    volumes:
+      - ./models:/root/.cache/huggingface
+    shm_size: '16g'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/v1/models')"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  gateway:
+    build: ./gateway
+    environment:
+      - CONSTITUTIONAL_PACK=/constitutional_pack
+      - VLLM_API_BASE=http://vllm:8000
+    volumes:
+      - ./constitutional_pack:/constitutional_pack:ro
+    ports:
+      - "8000:8000"
+    depends_on:
+      vllm:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  builder:
+    build: ./builder
+    ports:
+      - "3000:3000"
+    depends_on:
+      gateway:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          node -e "fetch('http://localhost:3000').then(()=>process.exit(0)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  postgres:
+    image: postgres:15-alpine
+    env_file:
+      - .env
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  minio:
+    image: minio/minio:RELEASE.2024-05-01T01-11-10Z
+    env_file:
+      - .env
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  qdrant:
+    image: qdrant/qdrant:v1.7.3
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+volumes:
+  pgdata:
+  minio_data:
+  qdrant_data:

--- a/examples/trifecta_example.json
+++ b/examples/trifecta_example.json
@@ -1,0 +1,13 @@
+{
+  "case": "demo",
+  "evidence": [
+    "Agent complied with scripture",
+    "Geometry validated",
+    "Policy review scheduled"
+  ],
+  "verdict": "pending",
+  "metadata": {
+    "submitted_by": "ark-cli",
+    "timestamp": "2024-06-01T00:00:00Z"
+  }
+}

--- a/gateway/.dockerignore
+++ b/gateway/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+*.pyo
+*.pytest_cache
+.venv
+.env

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app /app/app
+
+ENV CONSTITUTIONAL_PACK=/constitutional_pack
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+app = FastAPI(title="DeflexNet Gateway")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+PACK_ROOT = Path(os.getenv("CONSTITUTIONAL_PACK", "/constitutional_pack"))
+VLLM_API_BASE = os.getenv("VLLM_API_BASE", "http://vllm:8000")
+
+
+class CourtPlan(BaseModel):
+    """Minimal payload accepted by the court trifecta endpoint."""
+
+    case: str | None = None
+    evidence: list[str] | None = None
+    verdict: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def _read_section(section: str) -> dict[str, str]:
+    section_dir = PACK_ROOT / section
+    doc = section_dir / "README.md"
+    if doc.exists():
+        return {
+            "name": section,
+            "content": doc.read_text(encoding="utf-8")
+        }
+    return {"name": section, "content": ""}
+
+
+@lru_cache(maxsize=1)
+def load_constitutional_pack() -> dict[str, Any]:
+    if not PACK_ROOT.exists():
+        raise FileNotFoundError(f"constitutional pack not found at {PACK_ROOT}")
+
+    sections = ["Scripture", "Geometry", "Law"]
+    payload = {
+        "root": str(PACK_ROOT),
+        "sections": [_read_section(section) for section in sections],
+    }
+    return payload
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, Any]:
+    pack = load_constitutional_pack()
+    return {
+        "status": "ok",
+        "pack_sections": [section["name"] for section in pack["sections"]],
+        "vllm_api_base": VLLM_API_BASE,
+    }
+
+
+@app.post("/court/trifecta")
+async def court_trifecta(payload: CourtPlan) -> dict[str, Any]:
+    pack = load_constitutional_pack()
+
+    verdict = "PASS"
+    conditions: list[str] = []
+
+    if payload.verdict and payload.verdict.upper() != "PASS":
+        verdict = "PASS_WITH_CONDITIONS"
+        conditions.append("Existing verdict is not PASS, carrying forward as a condition.")
+
+    summary = {
+        "case": payload.case,
+        "evidence_items": len(payload.evidence or []),
+    }
+
+    return {
+        "result": verdict,
+        "conditions": conditions,
+        "pack": pack,
+        "summary": summary,
+        "payload": payload.model_dump(),
+    }
+
+
+@app.get("/agent/{path:path}")
+async def agent_stub(path: str) -> dict[str, str]:
+    return {"path": path, "status": "stub"}
+
+
+@app.get("/tools/{path:path}")
+async def tools_stub(path: str) -> dict[str, str]:
+    return {"path": path, "status": "stub"}
+
+
+@app.on_event("startup")
+def warm_pack() -> None:
+    """Validate the constitutional pack is present when the service boots."""
+    if not PACK_ROOT.exists():  # pragma: no cover - defensive guard
+        raise RuntimeError(f"constitutional pack not found at {PACK_ROOT}")
+    load_constitutional_pack()

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -104,6 +104,4 @@ async def tools_stub(path: str) -> dict[str, str]:
 @app.on_event("startup")
 def warm_pack() -> None:
     """Validate the constitutional pack is present when the service boots."""
-    if not PACK_ROOT.exists():  # pragma: no cover - defensive guard
-        raise RuntimeError(f"constitutional pack not found at {PACK_ROOT}")
     load_constitutional_pack()

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,2 +1,2 @@
-fastapi==0.111.0
+fastapi>=0.111.0,<1.0.0
 uvicorn[standard]==0.29.0

--- a/scripts/ark
+++ b/scripts/ark
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+CHANGES_DIR="$ROOT_DIR/.ark"
+COMPOSE_BIN=()
+
+usage() {
+  cat <<USAGE
+usage: ark {up|down|logs|check|court|dev}
+
+Commands:
+  up                 Build and start the stack in the background
+  down               Stop all running services
+  logs               Tail docker compose logs
+  check              Run environment validation (scripts/check_env.sh)
+  court <plan.json>  POST a plan to /court/trifecta and pretty-print the verdict
+  dev codegen "..."  Placeholder code generator (writes to .ark/)
+USAGE
+}
+
+ensure_compose_command() {
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE_BIN=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_BIN=(docker-compose)
+  else
+    echo "ark: docker compose is required" >&2
+    exit 1
+  fi
+}
+
+compose() {
+  if [[ ${#COMPOSE_BIN[@]} -eq 0 ]]; then
+    ensure_compose_command
+  fi
+  (cd "$ROOT_DIR" && "${COMPOSE_BIN[@]}" -f "$COMPOSE_FILE" "$@")
+}
+
+ensure_env_file() {
+  if [[ ! -f "$ROOT_DIR/.env" && -f "$ROOT_DIR/.env.sample" ]]; then
+    cp "$ROOT_DIR/.env.sample" "$ROOT_DIR/.env"
+    echo "ark: created .env from .env.sample"
+  fi
+}
+
+pretty_print_json() {
+  if command -v jq >/dev/null 2>&1; then
+    jq
+  else
+    cat
+  fi
+}
+
+extract_result() {
+  local payload="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$payload" | jq -r '.result' 2>/dev/null || echo ''
+  elif command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' "$payload" | python3 - <<'PY' 2>/dev/null || true
+import json
+import sys
+try:
+    data = json.loads(sys.stdin.read())
+    print(data.get("result", ""))
+except Exception:
+    pass
+PY
+  else
+    echo ''
+  fi
+}
+
+case "${1:-}" in
+  up)
+    ensure_env_file
+    compose up --build -d
+    ;;
+  down)
+    compose down
+    ;;
+  logs)
+    compose logs -f
+    ;;
+  check)
+    "$ROOT_DIR/scripts/check_env.sh"
+    ;;
+  court)
+    plan="${2:-}"
+    if [[ -z "$plan" ]]; then
+      echo "ark: plan file required" >&2
+      usage
+      exit 1
+    fi
+    if ! command -v curl >/dev/null 2>&1; then
+      echo "ark: curl is required for this command" >&2
+      exit 1
+    fi
+    if [[ -f "$plan" ]]; then
+      plan_path="$plan"
+    elif [[ -f "$ROOT_DIR/$plan" ]]; then
+      plan_path="$ROOT_DIR/$plan"
+    else
+      echo "ark: unable to locate plan file '$plan'" >&2
+      exit 1
+    fi
+    response="$(curl -sS -X POST http://localhost:8000/court/trifecta \
+      -H 'Content-Type: application/json' --data @"$plan_path")"
+    if [[ -z "$response" ]]; then
+      echo "ark: empty response from gateway" >&2
+      exit 1
+    fi
+    echo "$response" | pretty_print_json
+    result="$(extract_result "$response")"
+    if [[ -z "$result" ]]; then
+      echo "ark: unable to parse result field (install jq or python3 for validation)" >&2
+      exit 0
+    fi
+    if [[ "$result" == "PASS" || "$result" == "PASS_WITH_CONDITIONS" ]]; then
+      exit 0
+    fi
+    echo "ark: court verdict is '$result'" >&2
+    exit 1
+    ;;
+  dev)
+    if [[ "${2:-}" == "codegen" ]]; then
+      shift 2
+      mkdir -p "$CHANGES_DIR"
+      prompt="$*"
+      if [[ -z "$prompt" ]]; then
+        echo "ark: provide a prompt string" >&2
+        exit 1
+      fi
+      outfile="$CHANGES_DIR/changeset-$(date +%Y%m%d-%H%M%S).md"
+      {
+        echo "# TODO"
+        echo
+        echo "$prompt"
+      } > "$outfile"
+      echo "ark: wrote placeholder changeset to $outfile"
+    else
+      usage
+      exit 1
+    fi
+    ;;
+  ""|-h|--help)
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/ark
+++ b/scripts/ark
@@ -117,7 +117,8 @@ case "${1:-}" in
       echo "ark: unable to parse result field (install jq or python3 for validation)" >&2
       exit 0
     fi
-    if [[ "$result" == "PASS" || "$result" == "PASS_WITH_CONDITIONS" ]]; then
+    result_upper="$(echo "$result" | tr '[:lower:]' '[:upper:]')"
+    if [[ "$result_upper" == "PASS" || "$result_upper" == "PASS_WITH_CONDITIONS" ]]; then
       exit 0
     fi
     echo "ark: court verdict is '$result'" >&2

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failures=0
+warnings=0
+have_python=0
+
+print_header() {
+  echo "[check_env] $1"
+}
+
+require_command() {
+  local name="$1"
+  local cmd="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "[check_env] ✔ $name"
+    return 0
+  else
+    echo "[check_env] ✖ $name"
+    failures=$((failures + 1))
+    return 1
+  fi
+}
+
+optional_command() {
+  local name="$1"
+  local cmd="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "[check_env] ✔ $name"
+    return 0
+  else
+    echo "[check_env] ⚠ $name (optional)"
+    warnings=$((warnings + 1))
+    return 1
+  fi
+}
+
+check_docker_compose() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "[check_env] ✔ docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    echo "[check_env] ✔ docker-compose"
+  else
+    echo "[check_env] ✖ docker compose"
+    failures=$((failures + 1))
+  fi
+}
+
+check_docker_nvidia_runtime() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "[check_env] ✖ NVIDIA Container Toolkit runtime missing (docker unavailable)"
+    failures=$((failures + 1))
+    return
+  fi
+  if docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -qi 'nvidia'; then
+    echo "[check_env] ✔ NVIDIA Container Toolkit detected"
+  else
+    echo "[check_env] ✖ NVIDIA Container Toolkit runtime missing"
+    failures=$((failures + 1))
+  fi
+}
+
+check_port_available() {
+  local port="$1"
+  if (( have_python == 0 )); then
+    echo "[check_env] ⚠ port ${port} not checked (python3 missing)"
+    warnings=$((warnings + 1))
+    return
+  fi
+  if python3 - "$port" <<'PY'
+import socket
+import sys
+port = int(sys.argv[1])
+s = socket.socket()
+try:
+    s.bind(("0.0.0.0", port))
+except OSError:
+    sys.exit(1)
+finally:
+    s.close()
+PY
+  then
+    echo "[check_env] ✔ port ${port} available"
+  else
+    echo "[check_env] ✖ port ${port} busy"
+    failures=$((failures + 1))
+  fi
+}
+
+print_header "Checking critical executables"
+if require_command "docker" "docker"; then
+  docker --version
+fi
+check_docker_compose
+if require_command "nvidia-smi" "nvidia-smi"; then
+  nvidia-smi
+fi
+if optional_command "nvcc" "nvcc"; then
+  nvcc --version
+fi
+if require_command "python3" "python3"; then
+  python3 --version
+  have_python=1
+fi
+if optional_command "node" "node"; then
+  node --version
+fi
+if optional_command "pipx" "pipx"; then
+  pipx --version
+fi
+if optional_command "poetry" "poetry"; then
+  poetry --version
+fi
+if optional_command "uv" "uv"; then
+  uv --version
+fi
+if optional_command "git-lfs" "git-lfs"; then
+  git-lfs --version
+fi
+
+print_header "Validating Docker GPU runtime"
+check_docker_nvidia_runtime
+
+print_header "Checking required ports"
+for port in 8000 8001 3000 5432 9000 6333; do
+  check_port_available "$port"
+done
+
+if (( failures == 0 )); then
+  echo "[check_env] ✅ environment ready for launch"
+  if (( warnings > 0 )); then
+    echo "[check_env] ⚠ ${warnings} optional component(s) missing"
+  fi
+  exit 0
+else
+  echo "[check_env] ❌ environment check failed"
+  exit 1
+fi

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -52,7 +52,7 @@ check_docker_nvidia_runtime() {
     failures=$((failures + 1))
     return
   fi
-  if docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -qi 'nvidia'; then
+  if docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q '"nvidia"'; then
     echo "[check_env] ✔ NVIDIA Container Toolkit detected"
   else
     echo "[check_env] ✖ NVIDIA Container Toolkit runtime missing"

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -74,7 +74,7 @@ port = int(sys.argv[1])
 s = socket.socket()
 try:
     s.bind(("0.0.0.0", port))
-except OSError:
+except Exception:
     sys.exit(1)
 finally:
     s.close()


### PR DESCRIPTION
## Summary
- rebuild the CUDA devcontainer definition and VS Code config to include Python 3.11, Node 20, pipx, poetry, uv, and GPU passthrough defaults
- tighten the docker-compose stack with GPU reservations, health-checked service dependencies, and richer governance metadata surfaced through the FastAPI gateway and React builder
- expand the ark CLI and environment check script to validate prerequisites, bootstrap .env defaults, and pretty-print /court/trifecta verdicts while documenting the full workflow in README/ARCHITECTURE

## Testing
- `./scripts/ark check` *(fails in CI sandbox: docker/nvidia-smi unavailable)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_689cfb25edbc8321bf680eaf349cda1e)